### PR TITLE
Move Mocha to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
     "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "chai": "^3.5.0",
-    "mocha": "^3.2.0",
     "web3": "^0.18.4",
     "webpack": "^2.2.1"
+  },
+  "devDependencies": {
+    "mocha": "^3.2.0"
   }
 }


### PR DESCRIPTION
Growl@1.9.x (dependency of mocha) is failing security test. It is a false-negative as growl is only used for testing. By moving mocha to devDependency, node security test should pass again