### PR TITLE
Bump mocha to version 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "webpack": "^2.2.1"
   },
   "devDependencies": {
-    "mocha": "^3.2.0"
+    "mocha": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abi-decoder",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Nodejs and Javascript library for decoding data params and events from ethereum transactions\"",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updates package.json to move `mocha` up to version 4.0.0 and abi-decoder to 1.0.9

Previous versions of mocha used a version of growl that caused a security vulnerability. For example see:
- https://github.com/mochajs/mocha/issues/2791
- https://github.com/mochajs/mocha/pull/2930

The upgrade to mocha v4.0.0.0 has just been done in other libraries such as metamask: https://github.com/MetaMask/metamask-extension/pull/2264

Doing so in this project will allow user to avoid errors when running code against automated node security checks.

I am currently working on an overhaul to the UI of https://github.com/MetaMask/metamask-extension and we need this change to use abi-decoder. See an example of the failing node security checks here: https://nodesecurity.io/orgs/metamask/projects/6680bc33-6e65-4db7-a943-2aef82f2a881/2312