### PR TITLE
Fix decoding of multidimensional (u)int arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # abi-decoder
-Nodejs and Javascript library for decoding data params and events from etherem transactions
+Nodejs and Javascript library for decoding data params and events from ethereum transactions
 
 # Install
 ```

--- a/index.js
+++ b/index.js
@@ -76,13 +76,20 @@ function _decodeMethod(data) {
         const isInt = abiItem.inputs[index].type.indexOf("int") == 0;
 
         if (isUint || isInt) {
-          const isArray = Array.isArray(param);
-
-          if (isArray) {
-            parsedParam = param.map(val => new Web3().toBigNumber(val).toString());
-          } else {
-            parsedParam = new Web3().toBigNumber(param).toString();
-          }
+		  parsedParam = parseArrayNumber(param);
+			
+		  function parseArrayNumber (param2) {
+		    let parsedParam2 = param2;
+			const isArray = Array.isArray(param2);
+			
+			if (isArray) {
+			  parsedParam2 = param2.map(val => parseArrayNumber(val));
+			} else {
+			  parsedParam2 = new Web3().toBigNumber(param2).toString();
+			}
+			return parsedParam2;
+		  }
+		  
         }
         return {
           name: abiItem.inputs[index].name,


### PR DESCRIPTION
Multidimensional  uint arrays cause a throw in `_decodeMethod(data)`.

#10 fixed 1-dimensional arrays: `new Web3().toBigNumber([1,2,3,4]).toString()`  
But multidimensional still fails: `new Web3().toBigNumber([[1,2],[3,4]]).toString()`

Issue is also mentioned in #6
 
An example function from the 0x project
`batchFillOrKillOrders(address[5][] orderAddresses, uint256[6][] orderValues, uint256[] fillTakerTokenAmounts, uint8[] v, bytes32[] r, bytes32[] s)`
[Example transaction](https://etherscan.io/tx/0xc31856e5a568138df841a127b80edb688618ae59ed10681b8fc59680b11b1e8d)