### PR TITLE
Fix methodID of event type to 4 bytes

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ function padZeros (address) {
 
 function _decodeLogs(logs) {
   return logs.map(function(logItem) {
-    const methodID = logItem.topics[0].slice(2);
+    const methodID = logItem.topics[0].slice(2, 10);
     const method = state.methodIDs[methodID];
     if (method) {
       const logData = logItem.data;

--- a/index.js
+++ b/index.js
@@ -17,12 +17,8 @@ function _addABI(abiArray) {
     abiArray.map(function (abi) {
       if(abi.name){
         const signature = new Web3().sha3(abi.name + "(" + abi.inputs.map(function(input) {return input.type;}).join(",") + ")");
-        if(abi.type == "event"){
-          state.methodIDs[signature.slice(2)] = abi;
-        }
-        else{
-          state.methodIDs[signature.slice(2, 10)] = abi;
-        }
+        // methodID is only 4 byte
+        state.methodIDs[signature.slice(2, 10)] = abi;
       }
     });
 


### PR DESCRIPTION
## Issue
I want parse input data of ERC20 transfer transaction. For example: https://etherscan.io/tx/0x678346543b0bcc394f5bb57e749368023606571f599462db68e1d1e03d11dc6a

The `signature` of transfer function as `9059cbb2ab09eb219583f4a59a5d0623ade346d962bcd4e46b11da047c9049b`.
Now, the `addABI` function  add full signature without '0x' to methodIDs for event type.
Result as: 

```
{ a9059cbb2ab09eb219583f4a59a5d0623ade346d962bcd4e46b11da047c9049b:
   { anonymous: false,
     inputs:
      [ { indexed: true, name: '_to', type: 'address' },
        { indexed: false, name: '_value', type: 'uint256' },
        [length]: 2 ],
     name: 'transfer',
     type: 'event' },
...
```

But, real methodID of transaction (https://etherscan.io/tx/0x678346543b0bcc394f5bb57e749368023606571f599462db68e1d1e03d11dc6a) is only 4 bytes, so  is `a9059cbb`.

## solution
Fix `addABI` function for event type to use `signature.slice(2, 10)`

Knowledge may not be enough Do you have other problems?