### PR TITLE
Fix critical BN.js typecast bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,13 +183,11 @@ function _decodeLogs(logs) {
           param.type === "uint8" ||
           param.type === "int"
         ) {
-          // ensure to remove leading 0x for hex numbers
           if (typeof decodedP.value === "string" && decodedP.value.startsWith("0x")) {
-            decodedP.value = new BN(decodedP.value.slice(2), 16).toString(10);
+            decodedP.value = new BN(decodedP.value, 16).toString(10);
           } else {
             decodedP.value = new BN(decodedP.value).toString(10);
           }
-
         }
 
         decodedParams.push(decodedP);


### PR DESCRIPTION
As per discussion found here #84
This resolves a critical issue with `BN.js` typecast conversion when trying to `decodeLogs` for all integer types.